### PR TITLE
Optimize the Test component to make it more versatile in various scenarios

### DIFF
--- a/docs/.vuepress/components/Option.vue
+++ b/docs/.vuepress/components/Option.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="test_choice">
+    <div>{{ numero }}</div>
+    <div class="test_choices" v-if="c && c.length > 0">
+      <div class="test_choice_item" v-for="(d, i) in c" :key="i">
+        <div>({{ options[i] }})&nbsp;</div>
+        <div>{{ d }}</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    numero: String, // 选项编号
+    c: Array // 选项列表
+  },
+  data: function () {
+    return {
+      options: ['A', 'B', 'C', 'D']
+    };
+  }
+};
+</script>
+
+<style scoped>
+.test_choice {
+  margin-left: 1em;
+  line-height: 1.7;
+}
+
+.test_choices {
+  margin-left: 1em;
+  padding-left: .1em;
+}
+
+.test_choice_item {
+  display: flex;
+}
+</style>

--- a/docs/.vuepress/components/Test.vue
+++ b/docs/.vuepress/components/Test.vue
@@ -7,24 +7,13 @@
             <div class="test_triangle" @click="open = !open" :style="{ transform: open ? 'rotate(90deg)' : '' }"></div>
           </div>
         </div>
-        <div v-html="q" :style="{ marginLeft: nt ? '1em' : '' }"></div>
+        <div :style="{ marginLeft: nt ? '1em' : '' }">{{ q }}</div>
       </div>
 
       <div class="test_choices" v-if="c && c.length > 0">
         <div class="test_choice" v-for="(d, i) in c">
           <div>({{ options[i] }})&nbsp;</div>
           <div>{{ d }}</div>
-        </div>
-      </div>
-    </div>
-
-    <div v-if="qs">
-      <div class="test_summary">
-        <div class="test_triangle_box">
-          <div class="test_triangle" @click="open = !open" :style="{ transform: open ? 'rotate(90deg)' : '' }"></div>
-        </div>
-        <div>
-          <slot />
         </div>
       </div>
     </div>
@@ -48,7 +37,6 @@ export default {
     a: String, // 答案
     n: Boolean, // 无答案 -> 3 & 14 章
     nt: Boolean, // 无三角 -> 14 章
-    qs: Boolean // 有三角 -> 17 章
   },
   data: function() {
     return {

--- a/docs/.vuepress/components/Test.vue
+++ b/docs/.vuepress/components/Test.vue
@@ -2,47 +2,64 @@
   <div>
     <div v-if="q && q.length > 0">
       <div class="test_summary">
-        <div v-if="!nt">
-          <div class="test_triangle_box">
-            <div class="test_triangle" @click="open = !open" :style="{ transform: open ? 'rotate(90deg)' : '' }"></div>
+        <div class="test_triangle_box">
+          <div class="test_triangle" @click="toggleOpen" :style="{ cursor: cursorStyle, transform: transformStyle }">
           </div>
         </div>
-        <div :style="{ marginLeft: nt ? '1em' : '' }">{{ q }}</div>
+        <div v-html="q"></div>
       </div>
 
-      <div class="test_choices" v-if="c && c.length > 0">
-        <div class="test_choice" v-for="(d, i) in c">
-          <div>({{ options[i] }})&nbsp;</div>
-          <div>{{ d }}</div>
-        </div>
-      </div>
+      <!-- Use Option component to display choices -->
+      <Option :c="c"></Option>
     </div>
 
+    <!-- Slot for additional options always visible -->
+    <slot name="options"></slot>
+
+    <!-- Answer and explanation only visible when open -->
     <div v-if="!n">
       <div class="test_answer" v-if="open">
         <b>{{ a }}</b>
         <slot />
       </div>
 
-      <div class="test_answer_btn" @click="open = !open">{{ open ? 'Hide' : 'Show' }} Answer</div>
+      <div class="test_answer_btn" @click="toggleOpen">{{ open ? 'Hide' : 'Show' }} Answer</div>
     </div>
   </div>
 </template>
 
 <script>
+import Option from './Option.vue';
+
 export default {
+  components: {
+    Option
+  },
   props: {
     q: String, // 问题
     c: Array, // 选项
     a: String, // 答案
-    n: Boolean, // 无答案 -> 3 & 14 章
-    nt: Boolean, // 无三角 -> 14 章
+    n: Boolean, // 无答案 -> 第 3 章
   },
-  data: function() {
+  data: function () {
     return {
-      options: ['A', 'B', 'C', 'D'],
       open: false
     };
+  },
+  computed: {
+    cursorStyle() {
+      return this.n ? 'default' : 'pointer';
+    },
+    transformStyle() {
+      return this.open ? 'rotate(90deg)' : '';
+    }
+  },
+  methods: {
+    toggleOpen() {
+      if (!this.n) {
+        this.open = !this.open;
+      }
+    }
   }
 };
 </script>
@@ -57,19 +74,12 @@ export default {
   min-width: 1em;
   float: left;
   .test_triangle
-    cursor: pointer;
     margin-top: 0.5em;
     width: 0;
     height: 0;
     border-top: 0.36em solid transparent;
     border-left: 0.36 * 1.734em solid;
     border-bottom: 0.36em solid transparent;
-
-.test_choices
-  margin-left: 1em;
-  .test_choice
-    display: flex;
-    line-height: 1.7;
 
 .test_answer
   margin-top: 1em;

--- a/docs/.vuepress/components/Test.vue
+++ b/docs/.vuepress/components/Test.vue
@@ -4,10 +4,10 @@
       <div class="test_summary">
         <div v-if="!nt">
           <div class="test_triangle_box">
-            <div class="test_triangle" :style="{ transform: open ? 'rotate(90deg)' : '' }"></div>
+            <div class="test_triangle" @click="open = !open" :style="{ transform: open ? 'rotate(90deg)' : '' }"></div>
           </div>
         </div>
-        <div :style="{ marginLeft: nt ? '1em' : '' }">{{ q }}</div>
+        <div v-html="q" :style="{ marginLeft: nt ? '1em' : '' }"></div>
       </div>
 
       <div class="test_choices" v-if="c && c.length > 0">
@@ -21,9 +21,11 @@
     <div v-if="qs">
       <div class="test_summary">
         <div class="test_triangle_box">
-          <div class="test_triangle" :style="{ transform: open ? 'rotate(90deg)' : '' }"></div>
+          <div class="test_triangle" @click="open = !open" :style="{ transform: open ? 'rotate(90deg)' : '' }"></div>
         </div>
-        <div><slot /></div>
+        <div>
+          <slot />
+        </div>
       </div>
     </div>
 
@@ -67,6 +69,7 @@ export default {
   min-width: 1em;
   float: left;
   .test_triangle
+    cursor: pointer;
     margin-top: 0.5em;
     width: 0;
     height: 0;

--- a/docs/content/Chapter14.md
+++ b/docs/content/Chapter14.md
@@ -550,11 +550,13 @@ wh-ever 解释为 no matter wh-，是表示让步、条件的语气，它的功�
 
 <Test q="7. This custom, __, is slowly disappearing." :c="['of many centuries ago origin', 'which originated many centuries ago', 'with many centuries origin']" a="(B)">A 和 C 都在名词 origin 前面加上了短语（many centuries ago 和 many centuries）来修饰，可是名词前面只能用单词的形容词来修饰，所以错误。B 是正确的形容词从句。</Test>
 
-<Test q="8. I find it very unfair when __ I do is considered mediocre or a failure. I can be depressed for days because of __ happens." n></Test>
-
-<Test q="I." :c="['that', 'those', 'which', 'what']" n nt></Test>
-
-<Test q="II." :c="['who', 'what', 'that', 'where']" a="Ⅰ (D) II (B)" nt>两个位置都省掉了先行词，所以只能选择 what。 </Test>
+<Test q="8. I find it very unfair when __ I do is considered mediocre or a failure. I can be depressed for days because of __ happens." a="Ⅰ (D) II (B)">
+  <template v-slot:options>
+    <Option numero="I." :c="['that', 'those', 'which', 'what']"></Option>
+    <Option numero="II." :c="['who', 'what', 'that', 'where']"></Option>
+  </template>
+  <span>两个位置都省掉了先行词，所以只能选择 what。</span>
+</Test>
 
 <Test q="9. __ is elected President, corruption won't cease." :c="['Whatever', 'Who', 'How', 'Whoever']" a="(D)">空格前无先行词，只能选 A 或 D。而“当选总统”者应为“人”，故选 D。</Test>
 

--- a/docs/content/Chapter17.md
+++ b/docs/content/Chapter17.md
@@ -210,45 +210,25 @@
 
 #### 将下列各句中的关系从句（即画底线部分）改写为简化从句：
 
-<Test n qs>1. Medieval suits of armor, <u>which were developed for protection during battle</u>, are now placed in castles for decoration.</Test>
+<Test q="1. Medieval suits of armor, <u>which were developed for protection during battle</u>, are now placed in castles for decoration.">Medieval suits of armor, <u>developed for protection during battle</u>, are now placed in castles for decoration.</Test>
 
-<Test>Medieval suits of armor, <u>developed for protection during battle</u>, are now placed in castles for decoration.</Test>
+<Test q="2. The change of style in these paintings should be obvious to anyone <u>that is familiar with the artist's works</u>.">The change of style in these paintings should be obvious to anyone <u>familiar with the artist's works</u>.</Test>
 
-<Test n qs>2. The change of style in these paintings should be obvious to anyone <u>that is familiar with the artist's works</u>.</Test>
+<Test q="3. Islands are actually tips of underwater mountain peaks <u>that rise above water</u>.">Islands are actually tips of underwater mountain peaks <u>rising above waler</u>.</Test>
 
-<Test>The change of style in these paintings should be obvious to anyone <u>familiar with the artist's works</u>.</Test>
+<Test q="4. John Milton, <u>who was author of <i>Paradise Lost</i></u>, was a key member of Oliver Cromwell's cabinet.">John Milton, <u>author of <i>Paradise Lost</i></u>, was a key member of Oliver Cromwell's cabinet.</Test>
 
-<Test n qs>3. Islands are actually tips of underwater mountain peaks <u>that rise above water</u>.</Test>
+<Test q="5. The secretary thought that it might not be the best time <u>that she should ask her boss for a raise</u>.">The secretary thought that it might not be the best time <u>to ask her boss for a raise</u>.</Test>
 
-<Test>Islands are actually tips of underwater mountain peaks <u>rising above waler</u>.</Test>
+<Test q="6. Gold is one of the heaviest metals <u>that are known to man</u>.">Gold is one of the heaviest metals <u>known to man</u>.</Test>
 
-<Test n qs>4. John Milton, <u>who was author of <i>Paradise Lost</i></u>, was a key member of Oliver Cromwell's cabinet.</Test>
+<Test q="7. Here are some books <u>that your brother can use</u>.">Here are some books <u>for your brother to use</u>.</Test>
 
-<Test>John Milton, <u>author of <i>Paradise Lost</i></u>, was a key member of Oliver Cromwell's cabinet.</Test>
+<Test q="8. Sexual harassment, <u>which is a hotly debated issue in the work place</u>, will be the topic of the intercollegiate debate next week.">Sexual harassment, <u>a hotly debated issue in the work place</u>, will be the topic of the intercollegiate debate next week.</Test>
 
-<Test n qs>5. The secretary thought that it might not be the best time <u>that she should ask her boss for a raise</u>.</Test>
+<Test q="9. There's nothing left <u>that I can say now</u>.">There's nothing left <u>(for me) to say now</u>.</Test>
 
-<Test>The secretary thought that it might not be the best time <u>to ask her boss for a raise</u>.</Test>
-
-<Test n qs>6. Gold is one of the heaviest metals <u>that are known to man</u>.</Test>
-
-<Test>Gold is one of the heaviest metals <u>known to man</u>.</Test>
-
-<Test n qs>7. Here are some books <u>that your brother can use</u>.</Test>
-
-<Test>Here are some books <u>for your brother to use</u>.</Test>
-
-<Test n qs>8. Sexual harassment, <u>which is a hotly debated issue in the work place</u>, will be the topic of the intercollegiate debate next week.</Test>
-
-<Test>Sexual harassment, <u>a hotly debated issue in the work place</u>, will be the topic of the intercollegiate debate next week.</Test>
-
-<Test n qs>9. There's nothing left <u>that I can say now</u>.</Test>
-
-<Test>There's nothing left <u>(for me) to say now</u>.</Test>
-
-<Test n qs>10. People <u>that live along the waterfront</u> must be evacuated before the storm hits.</Test>
-
-<Test>People <u>living along the waterfront</u> must be evacuated before the storm hits.</Test>
+<Test q="10. People <u>that live along the waterfront</u> must be evacuated before the storm hits.">People <u>living along the waterfront</u> must be evacuated before the storm hits.</Test>
 
 #### 练习二
 

--- a/docs/content/Chapter18.md
+++ b/docs/content/Chapter18.md
@@ -294,45 +294,25 @@ whether 是由连接词 either…or 变造而成。在这个名词从句中，�
 
 #### 将下列各句中的名词从句（即画底线部分）改写为简化从句：
 
-<Test n qs>1. <u>That he sends flowers to his girlfriend every day</u> is the only way he can think of to gain her favor.</Test>
+<Test q="1. <u>That he sends flowers to his girlfriend every day</u> is the only way he can think of to gain her favor."><u>Sending flowers to his girlfriend every day</u> is the only way he can think of to gain her favor.</Test>
 
-<Test><u>Sending flowers to his girlfriend every day</u> is the only way he can think of to gain her favor.</Test>
+<Test q="2. <u>That the legislator was involved in the fraud</u> is rather obvious."><u>The legislator's being involved in the fraud</u> is rather obvious. <br /> 或 <br /> <u>The legislator's involvement in the fraud</u> is rather obvious.</Test>
 
-<Test n qs>2. <u>That the legislator was involved in the fraud</u> is rather obvious.</Test>
+<Test q="3. The student denied <u>that he had cheated in the exam</u>.">The student denied <u>having cheated in the exam</u>.</Test>
 
-<Test><u>The legislator's being involved in the fraud</u> is rather obvious. <br /> 或 <br /> <u>The legislator's involvement in the fraud</u> is rather obvious.</Test>
+<Test q="4. The researcher is certain <u>that he has found a solution</u>.">The researcher is certain <u>about having found a solution</u>.</Test>
 
-<Test n qs>3. The student denied <u>that he had cheated in the exam</u>.</Test>
+<Test q="5. The residents were not aware <u>that they were being exposed to radiation</u>.">The residents were not aware <u>of being exposed to radiation</u>. <br /> 或 <br /> The residents were not aware <u>of their exposure to radiation</u>.</Test>
 
-<Test>The student denied <u>having cheated in the exam</u>.</Test>
+<Test q="6. I consider <u>that this is a most unfortunate incident</u>.">I consider <u>this a most unfortunate incident</u>.</Test>
 
-<Test n qs>4. The researcher is certain <u>that he has found a solution</u>.</Test>
+<Test q="7. <u>That John comes to school late every day</u> cannot go on much longer."><u>John's coming to school late every day</u> cannot go on much longer.</Test>
 
-<Test>The researcher is certain <u>about having found a solution</u>.</Test>
+<Test q="8. <u>That he was named the new CEO</u> came as a surprise to everybody."><u>His being named the new CEO</u> came as a surprise to everybody.</Test>
 
-<Test n qs>5. The residents were not aware <u>that they were being exposed to radiation</u>.</Test>
+<Test q="9. I would like <u>that you can look after the kids for me this evening</u>.">I would like <u>you to look after the kids for me this evening</u>.</Test>
 
-<Test>The residents were not aware <u>of being exposed to radiation</u>. <br /> 或 <br /> The residents were not aware <u>of their exposure to radiation</u>.</Test>
-
-<Test n qs>6. I consider <u>that this is a most unfortunate incident</u>.</Test>
-
-<Test>I consider <u>this a most unfortunate incident</u>.</Test>
-
-<Test n qs>7. <u>That John comes to school late every day</u> cannot go on much longer.</Test>
-
-<Test><u>John's coming to school late every day</u> cannot go on much longer.</Test>
-
-<Test n qs>8. <u>That he was named the new CEO</u> came as a surprise to everybody.</Test>
-
-<Test><u>His being named the new CEO</u> came as a surprise to everybody.</Test>
-
-<Test n qs>9. I would like <u>that you can look after the kids for me this evening</u>.</Test>
-
-<Test>I would like <u>you to look after the kids for me this evening</u>.</Test>
-
-<Test n qs>10. It is a privilege <u>that one can live in these monumental times</u>.</Test>
-
-<Test>It is a privilege <u>to live in these monumental times</u>.</Test>
+<Test q="10. It is a privilege <u>that one can live in these monumental times</u>.">It is a privilege <u>to live in these monumental times</u>.</Test>
 
 #### 练习二
 

--- a/docs/content/Chapter19.md
+++ b/docs/content/Chapter19.md
@@ -181,45 +181,25 @@ being a student 因为有 being，所以 a student 很明显是补语，意思�
 
 #### 将下列各句中的副词从句（即画底线部分）改写为简化从句：
 
-<Test n qs>1. <u>While he was watching TV</u>, the boy heard a strange noise coming from the kitchen.</Test>
+<Test q="1. <u>While he was watching TV</u>, the boy heard a strange noise coming from the kitchen."><u>(While) waiching TV</u>, the boy heard a strange noise coming from the kitchen.</Test>
 
-<Test><u>(While) waiching TV</u>, the boy heard a strange noise coming from the kitchen.</Test>
+<Test q="2. <u>Because she lives with her parents</u>, the girl can't stay out very late."><u>Living with her parents</u>, the girl can't stay out very late.</Test>
 
-<Test n qs>2. <u>Because she lives with her parents</u>, the girl can't stay out very late.</Test>
+<Test q="3. <u>If you have finished your work</u>, you can help me with mine."><u>If having finished your work</u>，you can help me with mine.</Test>
 
-<Test><u>Living with her parents</u>, the girl can't stay out very late.</Test>
+<Test q="4. <u>As he is a law-enforcement officer</u>, he cannot drink on duty."><u>Being a law-enforcement officer</u>, he cannot drink on duty.</Test>
 
-<Test n qs>3. <u>If you have finished your work</u>, you can help me with mine.</Test>
+<Test q="5. The actor has been in a state of excitement <u>ever since he was nominated for the Oscar</u>.">The actor has been in a state of excitement <u>ever since being nominated for the Oscar</u>.</Test>
 
-<Test><u>If having finished your work</u>，you can help me with mine.</Test>
+<Test q="6. <u>After he addressed the congregation</u>, the minister left in a hurry."><u>After addressing the congregation</u>, the minister left in a hurry. <br /> 或 <br /> <u>Having addressed the congregation</u>, the minister left in a hurry.</Test>
 
-<Test n qs>4. <u>As he is a law-enforcement officer</u>, he cannot drink on duty.</Test>
+<Test q="7. <u>As it was rather warm</u>, we decided to go for a swim."><u>It being rather warm</u>, we decided to go for a swim.</Test>
 
-<Test><u>Being a law-enforcement officer</u>, he cannot drink on duty.</Test>
+<Test q="8. <u>When the students have all left</u>, the teacher started looking over their examination sheets."><u>The students having all left</u>, the teacher started looking over their examination sheets.</Test>
 
-<Test n qs>5. The actor has been in a state of excitement <u>ever since he was nominated for the Oscar</u>.</Test>
+<Test q="9. I know all about corn farming <u>because I grew up in a Southern farm</u>.">I know all about corn farming, <u>having grown up in a Southern farm</u>.</Test>
 
-<Test>The actor has been in a state of excitement <u>ever since being nominated for the Oscar</u>.</Test>
-
-<Test n qs>6. <u>After he addressed the congregation</u>, the minister left in a hurry.</Test>
-
-<Test><u>After addressing the congregation</u>, the minister left in a hurry. <br /> 或 <br /> <u>Having addressed the congregation</u>, the minister left in a hurry.</Test>
-
-<Test n qs>7. <u>As it was rather warm</u>, we decided to go for a swim.</Test>
-
-<Test><u>It being rather warm</u>, we decided to go for a swim.</Test>
-
-<Test n qs>8. <u>When the students have all left</u>, the teacher started looking over their examination sheets.</Test>
-
-<Test><u>The students having all left</u>, the teacher started looking over their examination sheets.</Test>
-
-<Test n qs>9. I know all about corn farming <u>because I grew up in a Southern farm</u>.</Test>
-
-<Test>I know all about corn farming, <u>having grown up in a Southern farm</u>.</Test>
-
-<Test n qs>10. <u>As the door remained shut</u>, the servant could not hear what was going on inside.</Test>
-
-<Test><u>The door remaining shut</u>, the servant could not hear what was going on inside.</Test>
+<Test q="10. <u>As the door remained shut</u>, the servant could not hear what was going on inside."><u>The door remaining shut</u>, the servant could not hear what was going on inside.</Test>
 
 #### 练习二
 

--- a/docs/content/Chapter20.md
+++ b/docs/content/Chapter20.md
@@ -206,45 +206,25 @@ be 动词是没有内容的字眼。在此加上 being 一词，纯粹是因应�
 
 #### 将下列各句中的副词从句（即画底线部分）改写为简化从句：
 
-<Test n qs>1. <u>After he was told to report to his supervisor</u>, the clerk left in a hurry.</Test>
+<Test q="1. <u>After he was told to report to his supervisor</u>, the clerk left in a hurry."><u>(Having been) told to report to his supervisor</u>, the clerk left in a hurry.</Test>
 
-<Test><u>(Having been) told to report to his supervisor</u>, the clerk left in a hurry.</Test>
+<Test q="2. <u>Although he was ordered to leave</u>, the soldier did not move an inch."><u>Although ordered to leave</u>, the soldier did not move an inch.</Test>
 
-<Test n qs>2. <u>Although he was ordered to leave</u>, the soldier did not move an inch.</Test>
+<Test q="3. The plan must be modified <u>before it is put into effect</u>.">The plan must be modified <u>before being put into effect</u>.</Test>
 
-<Test><u>Although ordered to leave</u>, the soldier did not move an inch.</Test>
+<Test q="4. <u>Because it had been bombed twice in the previous week</u>, the village was a total wreck."><u>(Having been) bombed twice in the previous week</u>, the village was a total wreck.</Test>
 
-<Test n qs>3. The plan must be modified <u>before it is put into effect</u>.</Test>
+<Test q="5. <u>When all things are considered</u>, I cannot truly say that this was an accident."><u>All things considered</u>, I cannot truly say that this was an accident.</Test>
 
-<Test>The plan must be modified <u>before being put into effect</u>.</Test>
+<Test q="6. <u>When the job was done</u>, the secretary went home."><u>The job done</u>, the secretary went home.</Test>
 
-<Test n qs>4. <u>Because it had been bombed twice in the previous week</u>, the village was a total wreck.</Test>
+<Test q="7. He took on two extra jobs <u>so that he could feed his family</u>.">He took on two extra jobs <u>(so as) to feed his family</u>.</Test>
 
-<Test><u>(Having been) bombed twice in the previous week</u>, the village was a total wreck.</Test>
+<Test q="8. <u>If you are in doubt</u>, you should look up the word in the dictionary."><u>If in doubt</u>, you should look up the word in the dictionary.</Test>
 
-<Test n qs>5. <u>When all things are considered</u>, I cannot truly say that this was an accident.</Test>
+<Test q="9. <u>Because pork is so expensive</u>, I'm buying beef instead."><u>With pork so expensive</u>, I'm buying beef instead. <br /> 或 <br /> <u>Pork being so expensive</u>, I'm buying beef instead.</Test>
 
-<Test><u>All things considered</u>, I cannot truly say that this was an accident.</Test>
-
-<Test n qs>6. <u>When the job was done</u>, the secretary went home.</Test>
-
-<Test><u>The job done</u>, the secretary went home.</Test>
-
-<Test n qs>7. He took on two extra jobs <u>so that he could feed his family</u>.</Test>
-
-<Test>He took on two extra jobs <u>(so as) to feed his family</u>.</Test>
-
-<Test n qs>8. <u>If you are in doubt</u>, you should look up the word in the dictionary.</Test>
-
-<Test><u>If in doubt</u>, you should look up the word in the dictionary.</Test>
-
-<Test n qs>9. <u>Because pork is so expensive</u>, I'm buying beef instead.</Test>
-
-<Test><u>With pork so expensive</u>, I'm buying beef instead. <br /> 或 <br /> <u>Pork being so expensive</u>, I'm buying beef instead.</Test>
-
-<Test n qs>10. <u>When we consider his handicap</u>, he has done very well indeed.</Test>
-
-<Test><u>Considering his handicap</u>, he has done very well indeed.</Test>
+<Test q="10. <u>When we consider his handicap</u>, he has done very well indeed."><u>Considering his handicap</u>, he has done very well indeed.</Test>
 
 #### 练习二
 

--- a/docs/content/Chapter21.md
+++ b/docs/content/Chapter21.md
@@ -272,82 +272,42 @@ that 引导的这个名词从句可以如此简化：主语 the Callege football
 
 #### 将下列各题中的句子写在一起成为复句或合句，然后再简化到最精简的地步：
 
-<Test n qs>1. Ben Book was educated in an art college. (because) <br />&emsp;Ben Book acts unusual. <br />&emsp;Ben Book deals with economic matters. (while)</Test>
+<Test q="1. Ben Book was educated in an art college. (because) <br />&emsp;Ben Book acts unusual. <br />&emsp;Ben Book deals with economic matters. (while)">Because he was educated in an art college. Ben Book acts unusual while he deals with economic matters. <br /> 简化为： <br /> Educated in an art college, Ben Book acts unusual while dealing with economic matters.</Test>
 
-<Test>Because he was educated in an art college. Ben Book acts unusual while he deals with economic matters. <br /> 简化为： <br /> Educated in an art college, Ben Book acts unusual while dealing with economic matters.</Test>
+<Test q="2. I'd like something. <br />&emsp;You will meet some people. (that)">I'd like that you will meet some people. <br /> 简化为： <br /> I'd like you to meet some people.</Test>
 
-<Test n qs>2. I'd like something. <br />&emsp;You will meet some people. (that)</Test>
+<Test q="3. I'm not sure. <br />&emsp;What should I do?">I'm not sure what I should do. <br /> 简化为： <br /> I'm not sure what to do.</Test>
 
-<Test>I'd like that you will meet some people. <br /> 简化为： <br /> I'd like you to meet some people.</Test>
+<Test q="4. He worked late into the night. <br />&emsp;He was trying to finish the report. (because)">He worked late into the night because he was trying to finish the report. <br /> 简化为： <br /> He worked late into the night trying to finish the report.</Test>
 
-<Test n qs>3. I'm not sure. <br />&emsp;What should I do?</Test>
+<Test q="5. The soldier was wounded in the war. (after) <br />&emsp;He was sent home.">After the soldier was wounded in the war, he was sent home. <br /> 简化为： <br /> (After being) wounded in the war, the soldier was sent home.</Test>
 
-<Test>I'm not sure what I should do. <br /> 简化为： <br /> I'm not sure what to do.</Test>
+<Test q="6. He used to smoke a lot. <br />&emsp;He got married. (before)">He used to smoke a lot before he got married. <br /> 简化为： <br /> He ie used to smoke a lot before getting married.</Test>
 
-<Test n qs>4. He worked late into the night. <br />&emsp;He was trying to finish the report. (because)</Test>
+<Test q="7. I am afraid. <br />&emsp;The Democratic Party might win a majority. (that)">I am afraid that the Democratic Party might win a majority. <br /> 简化为： <br /> I am afraid of the Democratic Party's winning a majority.</Test>
 
-<Test>He worked late into the night because he was trying to finish the report. <br /> 简化为： <br /> He worked late into the night trying to finish the report.</Test>
+<Test q="8. I have nothing better to do. (when) <br />&emsp;I enjoy something. <br />&emsp;I play poker. (that)">When I have nothing better to do, I enjoy that I play poker. <br /> 简化为： <br /> When I have nothing better to do, I enjoy playing poker.</Test>
 
-<Test n qs>5. The soldier was wounded in the war. (after) <br />&emsp;He was sent home.</Test>
+<Test q="9. Mike won the contest. (when) <br />&emsp;Mike was awarded ten thousand dollars.">When Mike won the contest, he was awarded ten thousand dollars. <br /> 简化为： <br /> (Upon) winning the contest. Mike was awarded ten thousand dollars.</Test>
 
-<Test>After the soldier was wounded in the war, he was sent home. <br /> 简化为： <br /> (After being) wounded in the war, the soldier was sent home.</Test>
+<Test q="10. The motorcyclist was pulled over by the police car. <br />&emsp;&nbsp; The motorcyclist did not wear a safety helmet. (who)">The motorcyclist who did not wear a safety helmet was pulled over by the police car. <br /> 简化为： <br /> The motorcyclist not wearing a safety helmet was pulled over by the police car.</Test>
 
-<Test n qs>6. He used to smoke a lot. <br />&emsp;He got married. (before)</Test>
+<Test q="11. The mayor declined. <br />&emsp;&nbsp; The mayor was a very busy person. (who) <br />&emsp;&nbsp; The mayor was asked to give a speech at the opening ceremony. (when)">The mayor, who was a very busy person, declined when he was asked to give a speech at the opening ceremony. <br /> 简化为： <br /> The mayor, a very busy person, declined when asked to give a speech at the opening ceremony.</Test>
 
-<Test>He used to smoke a lot before he got married. <br /> 简化为： <br /> He ie used to smoke a lot before getting married.</Test>
+<Test q="12. Tax rates are already very high. (although) <br />&emsp;&nbsp; Tax rates might be raised further to rein in inflation.">Although tax rates are already very high, they might be raised further to rein in inflation. <br /> 简化为： <br /> Although already very high, tax rates might be raised further to rein in inflation.</Test>
 
-<Test n qs>7. I am afraid. <br />&emsp;The Democratic Party might win a majority. (that)</Test>
+<Test q="13. The resort town is crowded. <br />&emsp;&nbsp; There has been an influx of tourists for the holiday season. (because)">The resort town is crowded because there has been an influx of tourists for the holiday season. <br /> 简化为： <br /> The resort town is crowded with an influx of tourists for the holiday season.</Test>
 
-<Test>I am afraid that the Democratic Party might win a majority. <br /> 简化为： <br /> I am afraid of the Democratic Party's winning a majority.</Test>
+<Test q="14. The student had failed in two tests. (though) <br />&emsp;&nbsp; The student was able to pass the course.">Though the student had failed in two tests, he was able to pass the course. <br /> 简化为： <br /> Though having failed in two tests, the student was able to pass the course.</Test>
 
-<Test n qs>8. I have nothing better to do. (when) <br />&emsp;I enjoy something. <br />&emsp;I play poker. (that)</Test>
+<Test q="15. The president avoided the issue. (that) <br />&emsp;&nbsp; This was obvious to the audience.">That the president avoided the issue was obvious to the audience. <br /> 或 <br /> It was obvious to the audience that the president avoided the issue. <br /> 简化为： <br /> The president's avoiding the issue was obvious to the audience. <br /> 或 <br /> The president's avoidance of the issue was obvious to the audicnce.</Test>
 
-<Test>When I have nothing better to do, I enjoy that I play poker. <br /> 简化为： <br /> When I have nothing better to do, I enjoy playing poker.</Test>
+<Test q="16. Anyone could tell he was upset. <br />&emsp;&nbsp; He had the look on his face. (because)">Anyone could tell he was upset because he had the look on his face. <br /> 简化为： <br /> Anyone could tell he was upset, with the look on his face.</Test>
 
-<Test n qs>9. Mike won the contest. (when) <br />&emsp;Mike was awarded ten thousand dollars.</Test>
+<Test q="17. Michael Crichton is in town. <br />&emsp;&nbsp; He is author of <i>Jurassic Park</i>. (who) <br />&emsp;&nbsp; He could promote his new novel. (so that)">Michacl Crichton, who is author of <i>Jurassic Park</i>, is in town so that he could promote his new novel. <br /> 简化为： <br /> Michacl Crichton, author of <i>Jurassic Park</i>, is in town to promote his new novel.</Test>
 
-<Test>When Mike won the contest, he was awarded ten thousand dollars. <br /> 简化为： <br /> (Upon) winning the contest. Mike was awarded ten thousand dollars.</Test>
+<Test q="18. I am a conservative. (although) <br />&emsp;&nbsp; I'd like to see something. <br />&emsp;&nbsp; The conservative party is chastised in the next election. (that)">Although I am a conservative, I'd like to see that the conservative party is chastised in the next election. <br /> 简化为： <br /> Although (being) a conservative, I'd like to see the conservative party chastised in the next election.</Test>
 
-<Test n qs>10. The motorcyclist was pulled over by the police car. <br />&emsp;&nbsp; The motorcyclist did not wear a safety helmet. (who)</Test>
+<Test q="19. The man found a fly in his soup. (when) <br />&emsp;&nbsp; The man called to the waiter.">When the man found a fly in his soup, he called to the waiter. <br /> 简化为： <br /> Finding a fly in his soup, the man called to the waiter.</Test>
 
-<Test>The motorcyclist who did not wear a safety helmet was pulled over by the police car. <br /> 简化为： <br /> The motorcyclist not wearing a safety helmet was pulled over by the police car.</Test>
-
-<Test n qs>11. The mayor declined. <br />&emsp;&nbsp; The mayor was a very busy person. (who) <br />&emsp;&nbsp; The mayor was asked to give a speech at the opening ceremony. (when)</Test>
-
-<Test>The mayor, who was a very busy person, declined when he was asked to give a speech at the opening ceremony. <br /> 简化为： <br /> The mayor, a very busy person, declined when asked to give a speech at the opening ceremony.</Test>
-
-<Test n qs>12. Tax rates are already very high. (although) <br />&emsp;&nbsp; Tax rates might be raised further to rein in inflation.</Test>
-
-<Test>Although tax rates are already very high, they might be raised further to rein in inflation. <br /> 简化为： <br /> Although already very high, tax rates might be raised further to rein in inflation.</Test>
-
-<Test n qs>13. The resort town is crowded. <br />&emsp;&nbsp; There has been an influx of tourists for the holiday season. (because)</Test>
-
-<Test>The resort town is crowded because there has been an influx of tourists for the holiday season. <br /> 简化为： <br /> The resort town is crowded with an influx of tourists for the holiday season.</Test>
-
-<Test n qs>14. The student had failed in two tests. (though) <br />&emsp;&nbsp; The student was able to pass the course.</Test>
-
-<Test>Though the student had failed in two tests, he was able to pass the course. <br /> 简化为： <br /> Though having failed in two tests, the student was able to pass the course.</Test>
-
-<Test n qs>15. The president avoided the issue. (that) <br />&emsp;&nbsp; This was obvious to the audience.</Test>
-
-<Test>That the president avoided the issue was obvious to the audience. <br /> 或 <br /> It was obvious to the audience that the president avoided the issue. <br /> 简化为： <br /> The president's avoiding the issue was obvious to the audience. <br /> 或 <br /> The president's avoidance of the issue was obvious to the audicnce.</Test>
-
-<Test n qs>16. Anyone could tell he was upset. <br />&emsp;&nbsp; He had the look on his face. (because)</Test>
-
-<Test>Anyone could tell he was upset because he had the look on his face. <br /> 简化为： <br /> Anyone could tell he was upset, with the look on his face.</Test>
-
-<Test n qs>17. Michael Crichton is in town. <br />&emsp;&nbsp; He is author of <i>Jurassic Park</i>. (who) <br />&emsp;&nbsp; He could promote his new novel. (so that)</Test>
-
-<Test>Michacl Crichton, who is author of <i>Jurassic Park</i>, is in town so that he could promote his new novel. <br /> 简化为： <br /> Michacl Crichton, author of <i>Jurassic Park</i>, is in town to promote his new novel.</Test>
-
-<Test n qs>18. I am a conservative. (although) <br />&emsp;&nbsp; I'd like to see something. <br />&emsp;&nbsp; The conservative party is chastised in the next election. (that)</Test>
-
-<Test>Although I am a conservative, I'd like to see that the conservative party is chastised in the next election. <br /> 简化为： <br /> Although (being) a conservative, I'd like to see the conservative party chastised in the next election.</Test>
-
-<Test n qs>19. The man found a fly in his soup. (when) <br />&emsp;&nbsp; The man called to the waiter.</Test>
-
-<Test>When the man found a fly in his soup, he called to the waiter. <br /> 简化为： <br /> Finding a fly in his soup, the man called to the waiter.</Test>
-
-<Test n qs>20. It is a warm day. (because) <br />&emsp;&nbsp; We will go to the beach.</Test>
-
-<Test>Because it is a warm day, we will go to the beach. <br /> 简化为： <br /> It being a warm day, we will go to the beach.</Test>
+<Test q="20. It is a warm day. (because) <br />&emsp;&nbsp; We will go to the beach.">Because it is a warm day, we will go to the beach. <br /> 简化为： <br /> It being a warm day, we will go to the beach.</Test>


### PR DESCRIPTION
## Motivation

The current `Test` component has a very strange usage method to meet certain use cases. This refactoring is mainly aimed at no longer using compromise methods to achieve the goal.

## Changes

1. Support toggling the display or hiding of answers through the foldable icon (black triangle).
2. Render the content of the question through `v-html`.
    ```
    // Before
    <Test n qs>1. Medieval suits of armor, <u>which were developed for protection during battle</u>, are now placed in castles for decoration.</Test>

    <Test>Medieval suits of armor, <u>developed for protection during battle</u>, are now placed in castles for decoration.</Test>
    
    // After
    <Test q="1. Medieval suits of armor, <u>which were developed for protection during battle</u>, are now placed in castles for decoration.">Medieval suits of armor, <u>developed for protection during battle</u>, are now placed in castles for decoration.</Test>
    ```
3. Split `Test` component and abstract out `Option` component.
    ```
	// Before
    <Test q="8. I find it very unfair when __ I do is considered mediocre or a failure. I can be depressed for days because of __ happens." n></Test>

	<Test q="I." :c="['that', 'those', 'which', 'what']" n nt></Test>

	<Test q="II." :c="['who', 'what', 'that', 'where']" a="Ⅰ (D) II (B)" nt>两个位置都省掉了先行词，所以只能选择 what。 </Test>
    
    // After
	<Test q="8. I find it very unfair when __ I do is considered mediocre or a failure. I can be depressed for days because of __ happens." a="Ⅰ (D) II (B)">
	  <template v-slot:options>
	    <Option numero="I." :c="['that', 'those', 'which', 'what']"></Option>
	    <Option numero="II." :c="['who', 'what', 'that', 'where']"></Option>
	  </template>
	  <span>两个位置都省掉了先行词，所以只能选择 what。</span>
	</Test>
    ```
    
[Demo Preview](https://blog.itswhat.me/grammar-club/)